### PR TITLE
Add Category classification

### DIFF
--- a/rbc_pdf_to_csv/cli.py
+++ b/rbc_pdf_to_csv/cli.py
@@ -9,24 +9,26 @@ from typing import List
 from .core import PDFProcessor
 
 
-def find_pdf_files(paths: List[str]) -> List[str]:
-    """Find PDF files from the given paths.
+def find_files(paths: List[str], extension: str = "pdf") -> List[str]:
+    """Find files with the given extension from the given paths.
 
     Args:
         paths: List of file or directory paths
+        extension: File extension to search for (without the dot)
 
     Returns:
-        List of PDF file paths
+        List of file paths with the specified extension
     """
-    pdf_files = []
+    files = []
 
     for path in paths:
         if os.path.isfile(path):
-            pdf_files.append(path)
+            if path.lower().endswith(f".{extension.lower()}"):
+                files.append(path)
         elif os.path.isdir(path):
-            pdf_files.extend(glob.glob(os.path.join(path, "**/*.pdf"), recursive=True))
+            files.extend(glob.glob(os.path.join(path, f"**/*.{extension}"), recursive=True))
 
-    return sorted(pdf_files)
+    return sorted(files)
 
 
 def main(args: List[str] = None) -> int:
@@ -54,7 +56,21 @@ def main(args: List[str] = None) -> int:
         )
 
         parser.add_argument(
-            "pdf_files",
+            "-c",
+            "--categorize-only",
+            action="store_true",
+            help="Categorize existing CSV file(s) with a Category column using the LLM. If no files specified, finds all CSV files in current directory and subdirectories."
+        )
+
+        parser.add_argument(
+            "-t",
+            "--training-data",
+            default=None,
+            help="Path to the training data CSV file to use for categorization"
+        )
+
+        parser.add_argument(
+            "files",
             default=glob.glob("**/*.pdf", recursive=True),
             nargs="*",
             help="Input PDF statements (default: **/*.pdf)",
@@ -62,13 +78,31 @@ def main(args: List[str] = None) -> int:
 
         parsed_args = parser.parse_args(args)
 
-        pdf_files = find_pdf_files(parsed_args.pdf_files)
+        processor = PDFProcessor()
+
+        # If --categorize-only is used, process those CSVs and exit
+        if parsed_args.categorize_only:
+            csv_files = find_files(parsed_args.files, "csv")
+
+            if len(csv_files) == 0:
+                print("No CSV files found.")
+                return 2
+
+            for i, csv_path in enumerate(csv_files):
+                print(f"Categorizing {i + 1}/{len(csv_files)}: {csv_path}...", end='', flush=True)
+                try:
+                    processor.categorize_transactions(csv_path, parsed_args.training_data)
+                    print("✅ Done")
+                except Exception as e:
+                    print(f"❌ Error: {e}")
+                    return 1
+            return 0
+
+        pdf_files = find_files(parsed_args.files, "pdf")
 
         if len(pdf_files) == 0:
             print("No PDF files found.")
             return 2
-
-        processor = PDFProcessor()
 
         for i, pdf_path in enumerate(pdf_files):
             print(f"Processing {i + 1}/{len(pdf_files)}: {pdf_path}.", end='', flush=True)
@@ -79,7 +113,7 @@ def main(args: List[str] = None) -> int:
                     print("⏭️ Skipping")
                     continue
 
-                processor.process_pdf(pdf_path, out_csv=out_csv)
+                processor.process_pdf(pdf_path, out_csv=out_csv, training_data_csv=parsed_args.training_data)
                 print("✅ Done")
             except Exception as e:
                 print(f"❌ Error: {e}")

--- a/rbc_pdf_to_csv/core.py
+++ b/rbc_pdf_to_csv/core.py
@@ -7,6 +7,8 @@ from typing import List, Optional
 import pandas as pd
 
 from .bank_statement import BankStatement
+from .llm_helper import LLMHelper
+from .prompts import CATEGORIZATION_PROMPT
 from .utils import clean_date_column, sanitize_description
 
 
@@ -62,12 +64,48 @@ class PDFProcessor:
         df = df[["Date", "File", "Description", "Amount"]]
         return df
 
-    def process_pdf(self, pdf_path: str, out_csv: Optional[str] = None) -> str:
+    def categorize_transactions(self, csv_path: str, training_data_csv: str) -> str:
+        """Categorize transactions in a CSV file using LLM.
+
+        Args:
+            csv_path: Path to the CSV file with transactions
+            sample_categories_path: Path to the sample categories CSV file
+
+        Returns:
+            Path to the categorized CSV file
+        """
+        # Read the transaction CSV
+        with open(csv_path, 'r') as f:
+            transactions_csv = f.read()
+
+        # Read the sample categories CSV
+        with open(training_data_csv, 'r') as f:
+            categories_csv = f.read()
+
+        # Create the prompt with both CSVs
+        prompt = f"{CATEGORIZATION_PROMPT}\n\nReference categories:\n{categories_csv}\n\nTransactions to categorize:\n{transactions_csv}"
+
+        # Get categorized CSV from LLM
+        try:
+            categorized_csv = LLMHelper.prompt(prompt, None)  # No image data needed for text-only prompt
+            # Clean up the response by removing markdown code blocks if present
+            categorized_csv = categorized_csv.removeprefix("```csv").removeprefix("```").removesuffix("```").strip()
+        except Exception as e:
+            raise RuntimeError(f"Failed to categorize transactions: {e}")
+
+        # Write the categorized CSV back to the same file
+        with open(csv_path, 'w') as f:
+            f.write(categorized_csv)
+
+        return csv_path
+
+    def process_pdf(self, pdf_path: str, out_csv: Optional[str] = None, training_data_csv: Optional[str] = None) -> str:
         """Process a single PDF file and convert to CSV.
 
         Args:
             pdf_path: Path to the PDF file
             out_csv: Path to the output CSV file (defaults to pdf_path.csv)
+            training_data_csv: Path to the training data CSV file (defaults to sample-categories.csv)
 
         Returns:
             Path to the generated CSV file
@@ -98,4 +136,13 @@ class PDFProcessor:
             df = self.process_bank_statement(df)
 
         df.to_csv(out_csv, index=False)
+
+        if training_data_csv is not None:
+            # Add categorization step
+            try:
+                self.categorize_transactions(out_csv, training_data_csv)
+            except Exception as e:
+                # Log the error but don't fail the entire process
+                print(f"Warning: Failed to categorize transactions: {e}")
+
         return out_csv

--- a/rbc_pdf_to_csv/llm_helper.py
+++ b/rbc_pdf_to_csv/llm_helper.py
@@ -49,12 +49,13 @@ class LLMHelper:
             cls._instance = cls(api_key)
         return cls._instance
 
-    def send_prompt(self, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]]]) -> str:
+    def send_prompt(self, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]], None] = None) -> str:
         """Internal implementation of prompt functionality.
 
         Args:
             prompt_text: The text prompt to send to the API
             data: Can be one of:
+                - None: Text-only prompt (no data)
                 - bytes: Single image/data bytes (assumes image/png)
                 - List[bytes]: Multiple image/data bytes (assumes image/png for all)
                 - Tuple[bytes, str]: Single bytes with mimetype
@@ -70,7 +71,10 @@ class LLMHelper:
         parts = [{"text": prompt_text}]
 
         # Handle different input types
-        if isinstance(data, bytes):
+        if data is None:
+            # Text-only prompt, no data to add
+            data_list = []
+        elif isinstance(data, bytes):
             # Single bytes object - assume image/png
             data_list = [(data, "image/png")]
         elif isinstance(data, list):
@@ -84,7 +88,7 @@ class LLMHelper:
             # Single (bytes, mimetype) tuple
             data_list = [data]
         else:
-            raise ValueError("data must be bytes, list of bytes, tuple of (bytes, str), or list of (bytes, str) tuples")
+            raise ValueError("data must be None, bytes, list of bytes, tuple of (bytes, str), or list of (bytes, str) tuples")
 
         # Add all data parts
         for item_bytes, mimetype in data_list:
@@ -114,12 +118,13 @@ class LLMHelper:
 
         return "\n".join(texts)
 
-    def prompt(self, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]]]) -> str:
+    def prompt(self, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]], None] = None) -> str:
         """Send a prompt to the Gemini API with optional data.
 
         Args:
             prompt_text: The text prompt to send to the API
             data: Can be one of:
+                - None: Text-only prompt (no data)
                 - bytes: Single image/data bytes (assumes image/png)
                 - List[bytes]: Multiple image/data bytes (assumes image/png for all)
                 - Tuple[bytes, str]: Single bytes with mimetype
@@ -135,12 +140,13 @@ class LLMHelper:
         return self.send_prompt(prompt_text, data)
 
     @classmethod
-    def prompt(cls, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]]], api_key: Optional[str] = None) -> str:
+    def prompt(cls, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]], None] = None, api_key: Optional[str] = None) -> str:
         """Send a prompt to the Gemini API with optional data. Auto-initializes the singleton if needed.
 
         Args:
             prompt_text: The text prompt to send to the API
             data: Can be one of:
+                - None: Text-only prompt (no data)
                 - bytes: Single image/data bytes (assumes image/png)
                 - List[bytes]: Multiple image/data bytes (assumes image/png for all)
                 - Tuple[bytes, str]: Single bytes with mimetype

--- a/rbc_pdf_to_csv/prompts.py
+++ b/rbc_pdf_to_csv/prompts.py
@@ -9,7 +9,17 @@ CREDIT_CARD_PROMPT = """You are a helpful assistant and an expert accountant. Ex
 Only output a valid CSV file with 4 fields and no other explanations.
 """
 
-BANK_ACCOUNT_PROMPT = """You are a helpful assistant and an expert accountant. Extract transactions from the provided bank statement, as if you were reading it naturally. Columns are right justified. Produce a CSV with the following columns:
+BANK_ACCOUNT_PROMPT = """You are a helpful assistant and an expert accountant. Your task is to read the provided bank statements naturally and extract transactions.
+
+I will provide you with a bank statement.
+
+Your job is to produce a CSV that extracts all the transactions.
+
+Guidelines for transactions:
+- columns are right justified, this is useful when determining which column a field belongs to
+- Remove all double quotes (`"`), commas (`,`) and dollar symbols (`$`)
+
+The following columns should be present in the output CSV:
   - "Date" with values in the format yyyy/mm/dd. Get the year from the line "Account statement from month day, year to month day, year".
   - "Description" with values inside double quotes. Do not include any `"` or `,` in the value. Include the foreign currency and value in paranthensis with the exchange rate prefixed with ` @ ` if available inside the double quotes.
   - "Withdrawals" (also might be called "Cheques & Debits"). Format the values as float with two decimal places. Do not put `$` or `,` in the value.
@@ -17,4 +27,24 @@ BANK_ACCOUNT_PROMPT = """You are a helpful assistant and an expert accountant. E
   - "Balance" with values formatted as float with two decimal places. Do not put `$` or `,` in the value.
 
 Only output a valid CSV file with 5 fields and no other explanations.
+"""
+
+CATEGORIZATION_PROMPT = """You are a helpful assistant and an expert accountant. Your task is to categorize financial transactions based on their descriptions and amounts.
+
+I will provide you with:
+1. A CSV file containing transactions with columns: Date, Description, Amount (and possibly other columns)
+2. A reference CSV file with sample categorized transactions
+
+Your job is to add a "Category" column to the transactions CSV by analyzing each transaction's description and amount, using the reference categories as a guide.
+
+Guidelines for categorization:
+- Use the exact category names from the reference file when possible
+- For new transactions not in the reference, choose the most appropriate existing category
+- Consider the transaction amount and description together
+- Be consistent with the categorization patterns shown in the reference
+- Only modify the "Category" column, do not change any other columns
+- Only use the categories lised in the reference file
+- When in doubt add a `~` to the category name
+
+Please output the complete CSV with the new "Category" column added, maintaining all existing columns and data. Only output the CSV data, no explanations.
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,38 +4,61 @@ import pytest
 import os
 from unittest.mock import patch, call, MagicMock
 
-from rbc_pdf_to_csv.cli import find_pdf_files, main
+from rbc_pdf_to_csv.cli import find_files, main
 
 
-class TestFindPDFFiles:
-    """Test PDF file discovery functionality."""
+class TestFindFiles:
+    """Test file discovery functionality."""
 
     @patch("os.path.isfile")
     @patch("os.path.isdir")
-    def test_find_pdf_files_single_file(self, mock_isdir, mock_isfile):
+    def test_find_files_single_pdf_file(self, mock_isdir, mock_isfile):
         """Test finding single PDF file."""
         mock_isfile.return_value = True
         mock_isdir.return_value = False
 
-        result = find_pdf_files(["test.pdf"])
+        result = find_files(["test.pdf"], "pdf")
         assert result == ["test.pdf"]
 
     @patch("os.path.isfile")
     @patch("os.path.isdir")
+    def test_find_files_single_csv_file(self, mock_isdir, mock_isfile):
+        """Test finding single CSV file."""
+        mock_isfile.return_value = True
+        mock_isdir.return_value = False
+
+        result = find_files(["test.csv"], "csv")
+        assert result == ["test.csv"]
+
+    @patch("os.path.isfile")
+    @patch("os.path.isdir")
     @patch("glob.glob")
-    def test_find_pdf_files_directory(self, mock_glob, mock_isdir, mock_isfile):
+    def test_find_files_directory_pdf(self, mock_glob, mock_isdir, mock_isfile):
         """Test finding PDF files in directory."""
         mock_isfile.return_value = False
         mock_isdir.return_value = True
         mock_glob.return_value = ["dir/file1.pdf", "dir/file2.pdf"]
 
-        result = find_pdf_files(["test_dir"])
+        result = find_files(["test_dir"], "pdf")
         assert result == ["dir/file1.pdf", "dir/file2.pdf"]
         mock_glob.assert_called_once_with("test_dir/**/*.pdf", recursive=True)
 
     @patch("os.path.isfile")
     @patch("os.path.isdir")
-    def test_find_pdf_files_mixed(self, mock_isdir, mock_isfile):
+    @patch("glob.glob")
+    def test_find_files_directory_csv(self, mock_glob, mock_isdir, mock_isfile):
+        """Test finding CSV files in directory."""
+        mock_isfile.return_value = False
+        mock_isdir.return_value = True
+        mock_glob.return_value = ["dir/file1.csv", "dir/file2.csv"]
+
+        result = find_files(["test_dir"], "csv")
+        assert result == ["dir/file1.csv", "dir/file2.csv"]
+        mock_glob.assert_called_once_with("test_dir/**/*.csv", recursive=True)
+
+    @patch("os.path.isfile")
+    @patch("os.path.isdir")
+    def test_find_files_mixed_pdf(self, mock_isdir, mock_isfile):
         """Test finding PDF files from mixed file and directory inputs."""
         def isfile_side_effect(path):
             return path == "file1.pdf"
@@ -47,29 +70,48 @@ class TestFindPDFFiles:
         mock_isdir.side_effect = isdir_side_effect
 
         with patch("glob.glob", return_value=["test_dir/file2.pdf"]):
-            result = find_pdf_files(["file1.pdf", "test_dir"])
+            result = find_files(["file1.pdf", "test_dir"], "pdf")
             assert result == ["file1.pdf", "test_dir/file2.pdf"]
 
     @patch("os.path.isfile")
     @patch("os.path.isdir")
-    def test_find_pdf_files_nonexistent(self, mock_isdir, mock_isfile):
-        """Test finding PDF files from nonexistent paths."""
+    def test_find_files_nonexistent(self, mock_isdir, mock_isfile):
+        """Test finding files from nonexistent paths."""
         mock_isfile.return_value = False
         mock_isdir.return_value = False
 
-        result = find_pdf_files(["nonexistent.pdf", "nonexistent_dir"])
+        result = find_files(["nonexistent.pdf", "nonexistent_dir"], "pdf")
         assert result == []
 
-    def test_find_pdf_files_empty_input(self):
-        """Test finding PDF files with empty input."""
-        result = find_pdf_files([])
+    def test_find_files_empty_input(self):
+        """Test finding files with empty input."""
+        result = find_files([], "pdf")
         assert result == []
+
+    @patch("os.path.isfile")
+    @patch("os.path.isdir")
+    def test_find_files_extension_filtering(self, mock_isdir, mock_isfile):
+        """Test that only files with the correct extension are returned."""
+        def isfile_side_effect(path):
+            return path in ["test.pdf", "test.csv", "test.txt"]
+
+        def isdir_side_effect(path):
+            return False
+
+        mock_isfile.side_effect = isfile_side_effect
+        mock_isdir.side_effect = isdir_side_effect
+
+        result_pdf = find_files(["test.pdf", "test.csv", "test.txt"], "pdf")
+        assert result_pdf == ["test.pdf"]
+
+        result_csv = find_files(["test.pdf", "test.csv", "test.txt"], "csv")
+        assert result_csv == ["test.csv"]
 
 
 class TestMain:
     """Test main CLI function."""
 
-    @patch("rbc_pdf_to_csv.cli.find_pdf_files")
+    @patch("rbc_pdf_to_csv.cli.find_files")
     @patch("rbc_pdf_to_csv.cli.PDFProcessor")
     def test_main_success(self, mock_processor_class, mock_find_files):
         """Test successful main execution."""
@@ -79,16 +121,16 @@ class TestMain:
 
         result = main(["--force", "file1.pdf", "file2.pdf"])
 
+        mock_find_files.assert_called_once_with(["file1.pdf", "file2.pdf"], "pdf")
         assert result == 0
-        mock_find_files.assert_called_once_with(["file1.pdf", "file2.pdf"])
         mock_processor.assert_has_calls(
             [
-                call.process_pdf("file1.pdf", out_csv="file1.csv"),
-                call.process_pdf("file2.pdf", out_csv="file2.csv"),
+                call.process_pdf("file1.pdf", out_csv="file1.csv", training_data_csv=None),
+                call.process_pdf("file2.pdf", out_csv="file2.csv", training_data_csv=None),
             ]
         )
 
-    @patch("rbc_pdf_to_csv.cli.find_pdf_files")
+    @patch("rbc_pdf_to_csv.cli.find_files")
     def test_main_no_files_found(self, mock_find_files):
         """Test main execution with no PDF files found."""
         mock_find_files.return_value = []
@@ -97,7 +139,7 @@ class TestMain:
 
         assert result == 2
 
-    @patch("rbc_pdf_to_csv.cli.find_pdf_files")
+    @patch("rbc_pdf_to_csv.cli.find_files")
     @patch("rbc_pdf_to_csv.cli.PDFProcessor")
     def test_main_default_files(self, mock_processor_class, mock_find_files):
         """Test main execution with default file discovery."""
@@ -109,7 +151,7 @@ class TestMain:
 
         assert result == 0
 
-    @patch("rbc_pdf_to_csv.cli.find_pdf_files")
+    @patch("rbc_pdf_to_csv.cli.find_files")
     @patch("rbc_pdf_to_csv.cli.PDFProcessor")
     def test_main_force_flag(self, mock_processor_class, mock_find_files):
         """Test main execution with force flag."""
@@ -122,11 +164,11 @@ class TestMain:
         assert result == 0
         mock_processor.assert_has_calls(
             [
-                call.process_pdf("file1.pdf", out_csv="file1.csv"),
+                call.process_pdf("file1.pdf", out_csv="file1.csv", training_data_csv=None),
             ]
         )
 
-    @patch("rbc_pdf_to_csv.cli.find_pdf_files")
+    @patch("rbc_pdf_to_csv.cli.find_files")
     @patch("rbc_pdf_to_csv.cli.PDFProcessor")
     def test_main_processor_error(self, mock_processor_class, mock_find_files):
         """Test main execution with processor error."""
@@ -139,3 +181,83 @@ class TestMain:
         result = main(["file1.pdf"])
 
         assert result == 1
+
+    @patch("rbc_pdf_to_csv.cli.find_files")
+    @patch("rbc_pdf_to_csv.cli.PDFProcessor")
+    def test_main_categorize_csv_specific_files(self, mock_processor_class, mock_find_files):
+        """Test main execution with --categorize-only and specific files."""
+        mock_find_files.return_value = ["file1.csv", "file2.csv"]
+        mock_processor = MagicMock()
+        mock_processor_class.return_value = mock_processor
+
+        result = main(["--categorize-only", "file1.csv", "file2.csv"])
+
+        assert result == 0
+        mock_find_files.assert_called_once_with(["file1.csv", "file2.csv"], "csv")
+        mock_processor.assert_has_calls(
+            [
+                call.categorize_transactions("file1.csv", None),
+                call.categorize_transactions("file2.csv", None),
+            ]
+        )
+
+    @patch("rbc_pdf_to_csv.cli.find_files")
+    @patch("rbc_pdf_to_csv.cli.PDFProcessor")
+    def test_main_categorize_csv_no_files(self, mock_processor_class, mock_find_files):
+        """Test main execution with --categorize-only and no files found."""
+        mock_find_files.return_value = []
+        mock_processor = MagicMock()
+        mock_processor_class.return_value = mock_processor
+
+        result = main(["--categorize-only", "nonexistent.csv"])
+
+        assert result == 2
+
+    @patch("rbc_pdf_to_csv.cli.find_files")
+    @patch("rbc_pdf_to_csv.cli.PDFProcessor")
+    def test_main_categorize_csv_error(self, mock_processor_class, mock_find_files):
+        """Test main execution with --categorize-only and processing error."""
+        mock_find_files.return_value = ["file1.csv"]
+        mock_processor = MagicMock()
+        mock_processor.categorize_transactions.side_effect = Exception("Categorization error")
+        mock_processor_class.return_value = mock_processor
+
+        result = main(["--categorize-only", "file1.csv"])
+
+        assert result == 1
+
+    @patch("rbc_pdf_to_csv.cli.find_files")
+    @patch("rbc_pdf_to_csv.cli.PDFProcessor")
+    def test_main_categorize_csv_with_custom_categories(self, mock_processor_class, mock_find_files):
+        """Test main execution with --categorize-only and custom categories file."""
+        mock_find_files.return_value = ["file1.csv"]
+        mock_processor = MagicMock()
+        mock_processor_class.return_value = mock_processor
+
+        result = main(["--categorize-only", "file1.csv", "--training-data", "custom-categories.csv"])
+
+        assert result == 0
+        mock_find_files.assert_called_once_with(["file1.csv"], "csv")
+        mock_processor.assert_has_calls(
+            [
+                call.categorize_transactions("file1.csv", "custom-categories.csv"),
+            ]
+        )
+
+    @patch("rbc_pdf_to_csv.cli.find_files")
+    @patch("rbc_pdf_to_csv.cli.PDFProcessor")
+    def test_main_pdf_with_custom_categories(self, mock_processor_class, mock_find_files):
+        """Test main execution with PDF processing and custom categories file."""
+        mock_find_files.return_value = ["file1.pdf"]
+        mock_processor = MagicMock()
+        mock_processor_class.return_value = mock_processor
+
+        result = main(["--force", "file1.pdf", "--training-data", "custom-categories.csv"])
+
+        assert result == 0
+        mock_find_files.assert_called_once_with(["file1.pdf"], "pdf")
+        mock_processor.assert_has_calls(
+            [
+                call.process_pdf("file1.pdf", out_csv="file1.csv", training_data_csv="custom-categories.csv"),
+            ]
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 from io import StringIO
+import tempfile
+import os
 
 from rbc_pdf_to_csv.core import PDFProcessor
 
@@ -70,6 +72,49 @@ class TestCore:
         processed_df.to_csv(result_csv, index=False)
         assert expected_csv == result_csv.getvalue()
 
+    def test_categorize_transactions(self):
+        """Test that transaction categorization works correctly."""
+        processor = PDFProcessor()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write("""Description,Amount,Category
+STARBUCKS 16466 OTTAWA ON,-6.50,Food
+LOBLAWS 82.2 NEPEAN ON,-57.80,Food
+BELL CANADA (OB) MONTREAL QC,-123.74,Food""")
+            temp_category_training_csv = f.name
+
+        # Create a temporary CSV file with sample transactions
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write("""Date,Description,Amount,File
+2024-01-01,STARBUCKS 16466 OTTAWA ON,-6.50,test.pdf
+2024-01-02,LOBLAWS 82.2 NEPEAN ON,-57.80,test.pdf
+2024-01-03,BELL CANADA (OB) MONTREAL QC,-123.74,test.pdf""")
+            temp_csv_path = f.name
+
+        try:
+            # Test categorization
+            result_path = processor.categorize_transactions(temp_csv_path, temp_category_training_csv)
+
+            # Verify the file was updated
+            assert result_path == temp_csv_path
+
+            # Read the categorized CSV and check for Category column
+            df = pd.read_csv(temp_csv_path)
+            assert "Category" in df.columns
+
+            # Verify the original columns are still there
+            assert "Date" in df.columns
+            assert "Description" in df.columns
+            assert "Amount" in df.columns
+            assert "File" in df.columns
+
+        finally:
+            # Clean up
+            if os.path.exists(temp_csv_path):
+                os.unlink(temp_csv_path)
+            if os.path.exists(temp_category_training_csv):
+                os.unlink(temp_category_training_csv)
+
     # def test_csv_structure_validation(self, samples_dir):
     #     """Test that all sample CSV files have the correct structure."""
     #     csv_files = list(samples_dir.glob("*.csv"))
@@ -125,7 +170,7 @@ class TestCore:
 
     #         # Parse both to compare structure
     #         raw_df = pd.read_csv(BytesIO(raw_text.removeprefix("```csv").removesuffix("```").encode()))
-    #         expected_df = pd.read_csv(BytesIO(expected_csv.encode()))
+    #         raw_df = pd.read_csv(BytesIO(expected_csv.encode()))
 
     #         # The processed CSV should have the same number of rows
     #         assert len(raw_df) == len(expected_df), "Row count mismatch"

--- a/tests/test_llm_helper.py
+++ b/tests/test_llm_helper.py
@@ -3,7 +3,7 @@
 import pytest
 import base64
 from unittest.mock import patch, MagicMock, mock_open
-from io import BytesIO
+from io import StringIO
 
 from rbc_pdf_to_csv.llm_helper import LLMHelper
 
@@ -111,8 +111,8 @@ class TestLLMHelper:
     def test_prompt_invalid_data_type(self):
         """Test prompting with invalid data type raises ValueError."""
         helper = LLMHelper("test-key")
-        with pytest.raises(ValueError, match="data must be bytes, list of bytes, tuple of \\(bytes, str\\), or list of \\(bytes, str\\) tuples"):
-            helper.prompt("test prompt", "invalid data")
+        with pytest.raises(ValueError, match="data must be None, bytes, list of bytes, tuple of \\(bytes, str\\), or list of \\(bytes, str\\) tuples"):
+            helper.prompt("test prompt", StringIO("invalid data"))
 
     @patch("rbc_pdf_to_csv.llm_helper.requests.post")
     def test_prompt_with_csv_markers(self, mock_post):


### PR DESCRIPTION
### TL;DR

Added transaction categorization functionality using LLM to automatically categorize bank transactions based on training data.

### What changed?

- Renamed `find_pdf_files` to `find_files` and made it more generic to support different file extensions
- Added `--categorize-only` CLI flag to categorize existing CSV files without processing PDFs
- Added `--training-data` option to specify a CSV file with sample categorized transactions
