### PR TITLE
Add retry for communication errors

### DIFF
--- a/rbc_pdf_to_csv/cli.py
+++ b/rbc_pdf_to_csv/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import glob
 import os
+import traceback
 import sys
 from typing import List
 
@@ -110,7 +111,7 @@ def main(args: List[str] = None) -> int:
             return 2
 
         for i, pdf_path in enumerate(pdf_files):
-            print(f"Processing {i + 1}/{len(pdf_files)}: {pdf_path}.", end='', flush=True)
+            print(f"Processing {i + 1}/{len(pdf_files)}: {os.path.basename(pdf_path)}.", end='', flush=True)
 
             try:
                 out_csv = pdf_path.removesuffix(".pdf") + ".csv"
@@ -122,6 +123,7 @@ def main(args: List[str] = None) -> int:
                 print("✅ Done")
             except Exception as e:
                 print(f"❌ Error: {e}")
+                print(f"Traceback: {traceback.format_exc()}")
                 return 1
 
         return 0

--- a/rbc_pdf_to_csv/core.py
+++ b/rbc_pdf_to_csv/core.py
@@ -1,6 +1,7 @@
 """Core PDF processing functionality."""
 
 import os
+import time
 from io import StringIO
 from typing import List, Optional
 
@@ -11,6 +12,9 @@ from .llm_helper import LLMHelper
 from .prompts import CATEGORIZATION_PROMPT
 from .utils import clean_date_column, sanitize_description
 
+# CSV retry configuration constants
+CSV_MAX_RETRIES = 3
+CSV_RETRY_DELAY = 3  # seconds
 
 class PDFProcessor:
     """Main class for processing PDF statements and converting to CSV."""
@@ -121,17 +125,27 @@ class PDFProcessor:
         # Create BankStatement instance for this PDF
         statement = BankStatement(pdf_path, self._debug)
 
+        # Get CSV text from LLM (only once to avoid retrying on network errors)
         try:
             csv_text = statement.pdf_to_csv()
         except Exception as e:
-            raise RuntimeError(f"Failed to convert PDF {pdf_path}: {e}")
+            raise RuntimeError(f"Failed to get CSV from LLM: {e}")
 
-        try:
-            df = pd.read_csv(StringIO(csv_text))
-        except Exception as e:
-            # Retry with more lenient parsing
-            csv_text = statement.pdf_to_csv()
-            df = pd.read_csv(StringIO(csv_text))
+        # Retry logic for CSV parsing errors only
+        last_error = None
+        for attempt in range(CSV_MAX_RETRIES + 1):
+            try:
+                if csv_text is None:
+                    csv_text = statement.pdf_to_csv()
+                df = pd.read_csv(StringIO(csv_text))
+                break
+            except Exception as e:
+                if attempt >= CSV_MAX_RETRIES:
+                    raise
+                delay = CSV_RETRY_DELAY * (2 ** attempt)
+                csv_text = None
+                print(f"\n ... retrying in {delay}s (bad CSV) #{attempt + 1}/{CSV_MAX_RETRIES}", end='', flush=True)
+                time.sleep(delay)
 
         # add a column with a static value on all rows
         df["File"] = os.path.basename(pdf_path)

--- a/rbc_pdf_to_csv/llm_helper.py
+++ b/rbc_pdf_to_csv/llm_helper.py
@@ -3,11 +3,16 @@
 import base64
 import json
 import os
+import time
 from typing import Optional, Union, List, Tuple
 
 import requests
 
 import mysecrets
+
+# Retry configuration constants
+MAX_RETRIES = 5
+BASE_DELAY = 3  # seconds
 
 class LLMHelper:
     """Helper class for LLM operations using Gemini API."""
@@ -21,8 +26,10 @@ class LLMHelper:
             api_key: Gemini API key. If None, uses mysecrets.GEMINI_API_KEY
         """
         self.api_key = api_key or mysecrets.GEMINI_API_KEY or os.getenv("GEMINI_API_KEY")
-        self.model = "gemini-2.0-flash"
+        self.model = "gemini-2.5-flash"
         self.api_url = f"https://generativelanguage.googleapis.com/v1/models/{self.model}:generateContent?key={self.api_key}"
+
+        self.session = requests.Session()
 
     @classmethod
     def initialize(cls, api_key: Optional[str] = None) -> 'LLMHelper':
@@ -95,7 +102,6 @@ class LLMHelper:
         for item_bytes, mimetype in data_list:
             data_b64 = str(base64.b64encode(item_bytes), "utf-8")
             parts.append({"inlineData": {"mimeType": mimetype, "data": data_b64}})
-
         body = {
             "contents": [
                 {
@@ -104,8 +110,52 @@ class LLMHelper:
             ],
         }
 
-        resp = requests.post(self.api_url, json=body)
-        resp.raise_for_status()
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                resp = self.session.post(self.api_url, json=body)
+
+                # If it's a 5xx error and we haven't exhausted retries, retry
+                if 500 <= resp.status_code < 600 and attempt < MAX_RETRIES:
+                    delay = BASE_DELAY * (2 ** attempt)  # Exponential backoff
+                    print(f"\n ... delaying {delay}s ({status_code}) #{attempt + 1}/{MAX_RETRIES}", end='', flush=True)
+                    # Close the connection to force reconnection on next request
+                    self.session.close()
+                    time.sleep(delay)
+                    continue
+
+                # For all other cases, raise the status error
+                resp.raise_for_status()
+                break
+
+            except requests.RequestException as e:
+                # Close the connection on any error to force reconnection
+                self.session.close()
+
+                status_code = getattr(e.response, 'status_code', 0)
+                if status_code == 429:
+                    # look for type.googleapis.com/google.rpc.RetryInfo in the response text and extract the retry delay
+                    if e.response.headers.get("content-type").startswith("application/json"):
+                        error_body = json.loads(e.response.text)
+                        # look in error.details[3].retryDelay where the details entry has "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                        retry_info = next((detail for detail in error_body.get("error", {}).get("details", []) if detail.get("@type") == "type.googleapis.com/google.rpc.RetryInfo"), None)
+                        retry_delay = retry_info.get("retryDelay", "0s") if retry_info else "0s"
+                        # convert to int if it is a string with a number and a unit
+                        if isinstance(retry_delay, str):
+                            delay = int(retry_delay.removesuffix("s")) + 1
+                        else:
+                            delay = retry_delay + 1
+                        print(f"\n ... delaying {delay}s ({status_code}) #{attempt + 1}/{MAX_RETRIES}", end='', flush=True)
+                        time.sleep(delay)
+                        continue
+
+                # If it's the last attempt or not a 5xx error, re-raise
+                if attempt == MAX_RETRIES or not (500 <= status_code < 600):
+                    raise
+
+                # Otherwise, retry with exponential backoff
+                delay = BASE_DELAY * (2 ** attempt)
+                print(f"\n ... delaying {delay}s ({status_code}) #{attempt + 1}/{MAX_RETRIES}", end='', flush=True)
+                time.sleep(delay)
 
         resp_data = json.loads(resp.text)
         texts = []
@@ -118,6 +168,15 @@ class LLMHelper:
             raise ValueError("No text content received from API")
 
         return "\n".join(texts)
+
+    def close(self):
+        """Close the session and clean up resources."""
+        if hasattr(self, 'session'):
+            self.session.close()
+
+    def __del__(self):
+        """Cleanup when the object is destroyed."""
+        self.close()
 
     def prompt(self, prompt_text: str, data: Union[bytes, List[bytes], Tuple[bytes, str], List[Tuple[bytes, str]], None] = None) -> str:
         """Send a prompt to the Gemini API with optional data.


### PR DESCRIPTION
### TL;DR

Improved error handling and retry logic for PDF processing and LLM API calls.

### What changed?

- Added retry logic with exponential backoff for CSV parsing errors
- Implemented robust error handling for LLM API calls with proper retry mechanisms
- Added detailed traceback information for debugging failures
- Upgraded to use `gemini-2.5-flash` model instead of `gemini-2.0-flash`
- Added proper session management with cleanup for HTTP requests
- Improved error messages to show only filenames rather than full paths
- Added retry delay calculation based on API response headers

### How to test?

1. Process PDFs that previously failed due to network errors or rate limiting
2. Test with malformed PDFs to verify error handling
3. Verify that retries work correctly by intentionally causing errors (e.g., disconnect network during processing)
4. Check that traceback information is properly displayed when errors occur

### Why make this change?

The tool was failing silently or without proper recovery when encountering network issues or API rate limits. These changes make the tool more resilient to transient failures, provide better debugging information, and ensure resources are properly cleaned up. The upgrade to the newer Gemini model should also provide better results.